### PR TITLE
Debounce search input

### DIFF
--- a/not.jst
+++ b/not.jst
@@ -1,0 +1,43 @@
+{{# def.definitions }}
+{{# def.errors }}
+{{# def.setupKeyword }}
+{{# def.setupNextLevel }}
+
+{{? {{# def.nonEmptySchema:$schema }} }}
+  {{
+    $it.schema = $schema;
+    $it.schemaPath = $schemaPath;
+    $it.errSchemaPath = $errSchemaPath;
+  }}
+
+  var {{=$errs}} = errors;
+
+  {{# def.setCompositeRule }}
+
+  {{
+    $it.createErrors = false;
+    var $allErrorsOption;
+    if ($it.opts.allErrors) {
+      $allErrorsOption = $it.opts.allErrors;
+      $it.opts.allErrors = false;
+    }
+  }}
+  {{= it.validate($it) }}
+  {{
+    $it.createErrors = true;
+    if ($allErrorsOption) $it.opts.allErrors = $allErrorsOption;
+  }}
+
+  {{# def.resetCompositeRule }}
+
+  if ({{=$nextValid}}) {
+    {{# def.error:'not' }}
+  } else {
+    {{# def.resetErrors }}
+  {{? it.opts.allErrors }} } {{?}}
+{{??}}
+  {{# def.addError:'not' }}
+  {{? $breakOnError}}
+    if (false) {
+  {{?}}
+{{?}}


### PR DESCRIPTION
Add a 300ms debounce to the global search input to reduce excessive API calls and improve perceived responsiveness. This prevents rapid repeated requests while typing and smooths UI updates by only triggering searches after the user pauses.